### PR TITLE
Fix invalid attempt to use terminal colors on Windows machines

### DIFF
--- a/stackit/stackit_core.py
+++ b/stackit/stackit_core.py
@@ -171,10 +171,15 @@ def getParser():
 
 class pColor:
     # https://github.com/ilovecode1/pyfancy/blob/master/pyfancy.py
-    END =           '\033[0m'
-    # Colors
-    BLUE =          '\033[94m'
-    RED =           '\033[91m'
+    if not os.name == 'nt':
+      END =           '\033[0m'
+      # Colors
+      BLUE =          '\033[94m'
+      RED =           '\033[91m'
+    else:
+      END = ''
+      BLUE = ''
+      RED = ''
 
 
 def main():


### PR DESCRIPTION
Since it only took me a few seconds, here's the proposed solution PR I mentioned in the comment earlier [here](https://github.com/lukasschwab/stackit/commit/059c4c91082337f662e20d2a2715f61a2b775945).

If you want to test it, and you are on a Mac for example.  Replace 
`if not os.name == 'nt'` with `if not os.name == 'posix'` and see if you get any terminal colors.  

You shouldn't. This will mirror that effect on Windows machines ('nt'). 

Concerns, questions?

Phil

Edit:  @lukasschwab if you approve this, should also look at reverting `README.md` changes.  
