### PR TITLE
fix `-e` issue addressed in #6

### DIFF
--- a/stackit/stackit_core.py
+++ b/stackit/stackit_core.py
@@ -11,7 +11,6 @@ import requests
 import subprocess
 import click
 import bs4
-import os
 
 
 if sys.version_info[:2] < (3, 0):
@@ -139,13 +138,9 @@ def get_term(config):
     if config.search:
         return config.search
     elif config.stderr:
-        commandlist = config.stderr.split()
-        command = commandlist[0]
-        # Get current working directory and replace spaces with '\ ' to stop errors
-        filename = (os.getcwd()).replace(' ', '\ ') + "/" + commandlist[1]
-        process = subprocess.Popen(command + " " + filename, stderr=subprocess.PIPE, shell=True)
-        output = process.communicate()[1]
-        return (str(output.splitlines()[-1]) + " ")
+        process = subprocess.Popen(config.stderr, stderr=subprocess.PIPE, shell=True)
+        output = process.communicate()[1].splitlines()
+        return "" if not len(output) else str(output[-1])
     return ""
 
 

--- a/stackit/stackit_core.py
+++ b/stackit/stackit_core.py
@@ -151,7 +151,7 @@ def get_term(config):
         # abord if no error
         if not len(output):
             click.echo(click.style(
-                "Your executable command doesn't raised any error. quit",
+                "Your executable does not raise an error.",
                 fg="red"))
             sys.exit(1)
 

--- a/stackit/stackit_core.py
+++ b/stackit/stackit_core.py
@@ -148,7 +148,7 @@ def get_term(config):
 
         output = process.communicate()[1].splitlines()
 
-        # abord if no error
+        # abort if no error
         if not len(output):
             click.echo(click.style(
                 "Your executable does not raise an error.",

--- a/stackit/stackit_core.py
+++ b/stackit/stackit_core.py
@@ -11,6 +11,7 @@ import requests
 import subprocess
 import click
 import bs4
+import os
 
 
 if sys.version_info[:2] < (3, 0):
@@ -138,9 +139,23 @@ def get_term(config):
     if config.search:
         return config.search
     elif config.stderr:
-        process = subprocess.Popen(config.stderr, stderr=subprocess.PIPE, shell=True)
+        # don't show stdout to user
+        with open(os.devnull, 'wb') as DEVNULL:
+            process = subprocess.Popen(
+                config.stderr,
+                stdout=DEVNULL,
+                stderr=subprocess.PIPE, shell=True)
+
         output = process.communicate()[1].splitlines()
-        return "" if not len(output) else str(output[-1])
+
+        # abord if no error
+        if not len(output):
+            click.echo(click.style(
+                "Your executable command doesn't raised any error. quit",
+                fg="red"))
+            sys.exit(1)
+
+        return str(output[-1])
     return ""
 
 


### PR DESCRIPTION
Maybe we should redirect `stdout` to `/dev/null`, we could do that by setting `Popen`'s `stdout` option to [os.devnull](https://docs.python.org/2/library/os.html#os.devnull)
