### PR TITLE
error message printed to stderr, exit with error code on failure

### DIFF
--- a/stackit/stackit_core.py
+++ b/stackit/stackit_core.py
@@ -69,7 +69,8 @@ def select(questions, num):
         else:
             click.echo(click.style(
                 "The input entered was not recognized as a valid choice.",
-                fg="red"))
+                fg="red",
+                err=True))
 
 
 def focus_question(questions):
@@ -85,7 +86,8 @@ def focus_question(questions):
         else:
             click.echo(click.style(
                 "The input entered was not recognized as a valid choice.",
-                fg="red"))
+                fg="red",
+                err=True))
 
 
 def _search(config):
@@ -109,12 +111,15 @@ def _search(config):
             print_question(question, count)
             if count % NUM_RESULTS == 0:
                 focus_question(question_logs)
-    
+
     if not questions:
-            click.echo(
-                click.style("Your search \'{0}\' with tags \'{1}\' returned no results.".format(config.term,config.tag),
-                fg="red"))
-            
+        click.echo(
+            click.style(
+                "Your search \'{0}\' with tags \'{1}\' returned no results.".format(config.term, config.tag),
+                fg="red",
+                err=True))
+        sys.exit(1)
+
 
 def print_question(question, count):
     # questionurl gives the url of the SO question
@@ -208,6 +213,13 @@ def main(config, search, stderr, tag, verbose, version):
         _search(config)
     elif version:
         click.echo("Version {VERSION_NUM}".format(**globals()))
+    else:
+        click.echo(
+            click.style(
+                "No argument provided, use --help for help",
+                fg="red",
+                err=True))
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Features:
- error messages are now printed to `stderr`
- when program failed it return an error code

error code use case:

```
stackit -e "python broken_app.py" && vim broken_app.py
```

if no error question is return by `stackit` vim is not launched

if questions are return I can found a solution on StackOverflow and fix my `broken_app.py` using [vim](http://www.vim.org/images/vim_drill_small.JPG)
