### PR TITLE
Feature/add test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+
+python:
+  - "3.5"
+install:
+  - "pip3 install -r ./requirements-dev.txt"
+  - "pip3 -e ."
+script:
+ #- "python -m flake8 ./stackit"
+ - "python -m pytest -v ./tests/ --cov=stackit"
+after_success:
+  #- bash <(curl -s https://codecov.io/bash)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest==3.0.6
+pytest-cov==2.4.0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,63 @@
+"""test main func."""
+from itertools import product
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.mark.parametrize(
+    'search, stderr, tag, verbose, version',
+    product(
+        [None, 'search_input'],
+        [None, 'stderr_input'],
+        [None, 'tag_input'],
+        [None, True],
+        [None, True],
+    )
+)
+def test_main(search, stderr, tag, verbose, version):
+    """test main."""
+    argv = []
+    no_input_given = search is None and \
+        stderr is None and \
+        verbose is None and \
+        version is None
+
+    if search is not None:
+        argv.extend(['--search',  search])
+    if stderr is not None:
+        argv.extend(['--search', argv])
+    if tag is not None:
+        argv.extend(['--tag', tag])
+    if verbose is not None:
+        argv.extend(['--verbose'])
+    if version is not None:
+        argv.extend(['--version'])
+    with mock.patch('stackit.stackit_core.search_verbose') as m_search_verbose, \
+            mock.patch('stackit.stackit_core._search') as m_search, \
+            mock.patch('stackit.stackit_core.get_term') as m_get_term, \
+            mock.patch('stackit.stackit_core.click') as m_click:
+        from stackit import stackit_core
+        runner = CliRunner()
+        # with pytest.raises(ValueError):
+        if no_input_given:
+            result = runner.invoke(stackit_core.main, argv)
+            result_vars = vars(result)
+            result_vars.pop('runner')
+            result_vars.pop('exc_info')
+            result_vars.pop('exception')
+            assert result_vars == {
+                'output_bytes': b'',
+                'exit_code': 1
+            }
+        else:
+            result = runner.invoke(stackit_core.main, argv)
+            assert result.exit_code == 0
+            if verbose:
+                m_search_verbose.assert_called_once_with(m_get_term.return_value)
+            elif search or stderr:
+                m_search.assert_called_once_with(mock.ANY)
+            elif version:
+                m_click.echo.assert_called_once_with(
+                    'Version {}'.format(stackit_core.VERSION_NUM))

--- a/tests/test_stackit_core.py
+++ b/tests/test_stackit_core.py
@@ -1,0 +1,232 @@
+"""test module."""
+from itertools import product
+from unittest import mock
+
+import pytest
+
+
+def test_config_init():
+    """test init."""
+    from stackit.stackit_core import Config
+    obj = Config()
+    vars(obj) == {
+        'search': False,
+        'stderr': False,
+        'tag': False,
+        'versbose': False,
+    }
+
+
+@pytest.mark.parametrize(
+    'prompt_side_effect',
+    [
+        ['b', 'q'],
+        ['z', 'q'],  # random char input at the beginning
+    ]
+)
+def test_select(prompt_side_effect):
+    """test func."""
+    q_json_link = mock.Mock()
+    question = mock.Mock()
+    question.json = {'link': q_json_link}
+    questions = [question]
+    num = 1
+    prompt_msg = 'Enter b to launch browser, x to return to search, or q to quit'
+    prompt_msg_error = 'The input entered was not recognized as a valid choice.'
+    with mock.patch('stackit.stackit_core.print_full_question') as print_fq, \
+            mock.patch('stackit.stackit_core.click') as m_click:
+        m_click.prompt.side_effect = prompt_side_effect
+        from stackit.stackit_core import select
+        with pytest.raises(SystemExit):
+            select(questions, num)
+        print_fq.assert_called_once_with(questions[0])
+        if prompt_side_effect[0] == 'b':
+            m_click.assert_has_calls([
+                mock.call.prompt(prompt_msg),
+                mock.call.launch(q_json_link),
+                mock.call.prompt(prompt_msg)
+            ])
+        elif prompt_side_effect[0] == 'x':
+            pass
+        else:
+            m_click.assert_has_calls([
+                mock.call.prompt(prompt_msg),
+                mock.call.style(prompt_msg_error, err=True, fg='red'),
+                mock.call.echo(m_click.style.return_value),
+                mock.call.prompt(prompt_msg)
+            ])
+
+
+@pytest.mark.parametrize('num', [1])
+def test_select_func_and_return_to_search(num):
+    """test func."""
+    q1 = mock.Mock()
+    q2 = mock.Mock()
+    questions = [q1, q2]
+    prompt_side_effect = ['x', 'q']
+    with mock.patch('stackit.stackit_core.print_full_question') as print_fq, \
+            mock.patch('stackit.stackit_core.click') as m_click, \
+            mock.patch('stackit.stackit_core.print_question') as print_q:
+        m_click.prompt.side_effect = prompt_side_effect
+        from stackit import stackit_core
+        stackit_core.NUM_RESULTS = 2
+        stackit_core.select(questions, num)
+        print_fq.assert_called_once_with(questions[0])
+        print_q.assert_has_calls([
+            mock.call(q1, 1),
+            mock.call(q2, 2),
+        ])
+
+
+@pytest.mark.parametrize(
+    'prompt_side_effect',
+    [
+        ['m'],
+        ['q'],
+        ['1', 'm'],
+        ['z', 'm'],  # random char
+    ]
+)
+def test_focus_question(prompt_side_effect):
+    """test func."""
+    question = mock.Mock()
+    questions = [question]
+    prompt_msg = "Enter m for more, a question number to select, or q to quit"
+    prompt_msg_error = "The input entered was not recognized as a valid choice."
+    first_prompt = prompt_side_effect[0]
+    with mock.patch('stackit.stackit_core.click') as m_click, \
+            mock.patch('stackit.stackit_core.select') as m_select:
+        m_click.prompt.side_effect = prompt_side_effect
+        from stackit import stackit_core
+        if first_prompt == 'q':
+            with pytest.raises(SystemExit):
+                stackit_core.focus_question(questions=[question])
+        else:
+            stackit_core.focus_question(questions=questions)
+        if first_prompt == 'm' or first_prompt == 'q':
+            pass
+        elif first_prompt.isnumeric() and int(first_prompt) <= len(questions):
+            m_select.assert_called_once_with(questions, int(first_prompt))
+        else:
+            m_click.assert_has_calls([
+                mock.call.prompt(prompt_msg),
+                mock.call.style(prompt_msg_error, err=True, fg='red'),
+                mock.call.echo(m_click.style.return_value),
+                mock.call.prompt(prompt_msg)
+            ])
+
+
+@pytest.mark.parametrize(
+    'questions',
+    [
+        [],
+        [mock.Mock()],
+        [mock.Mock(), mock.Mock()],
+    ]
+)
+def test_search(questions):
+    """test func."""
+    if questions:
+        for idx, _ in enumerate(questions):
+            # add random number
+            questions[idx].json = {'accepted_answer_id': 1234}
+    config = mock.Mock()
+    with mock.patch('stackit.stackit_core.click'),\
+            mock.patch('stackit.stackit_core.so') as m_so, \
+            mock.patch('stackit.stackit_core.print_question'),\
+            mock.patch('stackit.stackit_core.focus_question'):
+        m_so.search_advanced.return_value = questions
+        from stackit import stackit_core
+        stackit_core.NUM_RESULTS = 2
+        if not questions:
+            with pytest.raises(SystemExit):
+                stackit_core._search(config)
+            return
+        else:
+            stackit_core._search(config)
+
+
+def test_print_question():
+    """test func."""
+    question = mock.Mock()
+    question.title = 'Random title.'
+    question.json = {'accepted_answer_id': 1234}
+    count = mock.Mock()
+    with mock.patch('stackit.stackit_core.click') as m_click, \
+            mock.patch('stackit.stackit_core.h') as m_h, \
+            mock.patch('stackit.stackit_core.so'):
+        m_h.handle.return_value = 'Random answer'
+        m_click.style.return_value = 'Random header.'
+        from stackit import stackit_core
+        stackit_core.print_question(question, count)
+
+
+@pytest.mark.parametrize(
+    'config_search, raw_output',
+    product(
+        [True, False],
+        ['', 'line1\nline2'],
+    )
+)
+def test_get_term(config_search, raw_output):
+    """test func."""
+    config = mock.Mock()
+    config.search = config_search
+    raw_output = ''
+    comm_result = [None, raw_output]
+    with mock.patch('stackit.stackit_core.click'),\
+            mock.patch('stackit.stackit_core.open'),\
+            mock.patch('stackit.stackit_core.subprocess') as m_subprocess:
+        m_subprocess.Popen.return_value.communicate.return_value = comm_result
+        from stackit import stackit_core
+        if not config_search:
+            with pytest.raises(SystemExit):
+                stackit_core.get_term(config)
+        else:
+            res = stackit_core.get_term(config)
+            assert res
+
+
+def test_print_full_question():
+    """test func."""
+    question = mock.Mock()
+    question.json = {'accepted_answer_id': 1234}
+    question.title = 'Question title.'
+    with mock.patch('stackit.stackit_core.click') as m_click,\
+            mock.patch('stackit.stackit_core.so'),\
+            mock.patch('stackit.stackit_core.h') as m_h:
+        m_h.handle.side_effect = ['Question text.', 'Answer.']
+        m_click.style.return_value = 'Header'
+        from stackit import stackit_core
+        stackit_core.print_full_question(question)
+        m_click.assert_has_calls([
+            mock.call.style(
+                '\n\n'
+                '------------------------------QUESTION-----------------------------------'
+                '\n\n'
+                'Question title.\n'
+                'Question text.',
+                fg='blue'
+            ),
+            mock.call.echo(
+                'Header\n'
+                '-------------------------------ANSWER------------------------------------'
+                'Answer.'
+            )
+        ])
+
+
+def test_search_verbose():
+    """test func."""
+    term = mock.Mock()
+    questions = [mock.Mock()]
+    with mock.patch('stackit.stackit_core.so') as m_so, \
+            mock.patch('stackit.stackit_core.Sort') as m_sort, \
+            mock.patch('stackit.stackit_core.print_full_question') as print_fq:
+        m_so.search_advanced.return_value = questions
+        from stackit import stackit_core
+        # run
+        stackit_core.search_verbose(term)
+        # test
+        m_so.search_advanced.assert_called_once_with(q=term, sort=m_sort.Votes)
+        print_fq.assert_called_once_with(questions[0])


### PR DESCRIPTION
hi, i add test using pytest. there is also travis config, which can be used for travis-ci. 

on travis config there is also option to run flake8 as linter and other option to send coverage report to codecov. you can just put uncomment to enable those options.